### PR TITLE
add SAMtools and update to install HISAT2 with conda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ---
+## [2.2.1] - 2021-05-22
+### Added
+- Added SAMtools v1.12 
+
+---
 
 ## [2.2.1] - 2021-05-05
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,12 @@
+FROM blcdsdockerregistry/bl-base:1.0.0 AS builder
+
+RUN conda create -qy -p /usr/local \
+    -c bioconda \
+    -c conda-forge \
+    samtools==1.12 \
+    hisat2==2.2.1
+
 FROM ubuntu:20.04
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    python \
-    unzip \
-    wget \
-    && rm -rf /var/lib/apt/lists/*
-
-# install hisat2
-RUN wget https://cloud.biohpc.swmed.edu/index.php/s/oTtGWbWjaxsQ2Ho/download && \
-    echo "e2b43f6f55c8d8e5a46648cf86ad4af004671ec859fcca0c52edc392bdf6f03094f4de41b1a051a6866cf4e48c9e61e9f26cd145957eeacf999ce0c0815f2120  download" | sha512sum --status -c - && \
-    unzip download && \
-    rm download && \
-    cd hisat2-2.2.1 && \
-    cp -t /usr/local/bin hisat2 hisat2-align-s hisat2-align-l hisat2-build hisat2-build-s hisat2-build-l hisat2-inspect hisat2-inspect-s hisat2-inspect-l
+COPY --from=builder /usr/local /usr/local
 
 LABEL maintainer="Julie Livingstone <jlivingstone@mednet.ucla.edu>"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # docker-HISAT2
 Dockerfile for HISAT2, which "is a fast and sensitive alignment program for mapping next-generation sequencing reads (whole-genome, transcriptome, and exome sequencing data) against the general human population (as well as against a single reference genome)."
 
-The HISAT2 image is located in the Boutros Lab Docker Hub repo: https://hub.docker.com/repository/docker/blcdsdockerregistry/hisat2
+SAMtools is also installed for use in the align-RNA and align-DNA pipelines.
+This is because many aligners (e.g. BWA-MEM2 and HISAT2) only support outputting the uncompressed SAM, which causes a burden on the hard disk IO and limits the performace.
+
+The HISAT2 image with SAMtools is located in the Boutros Lab Docker Hub repo: https://hub.docker.com/repository/docker/blcdsdockerregistry/hisat2_samtools-1.12
 
 # Documentation
 HISAT2 manual is [here](http://daehwankimlab.github.io/hisat2/manual/)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -4,7 +4,7 @@ Description: 'Docker repository for the HISAT2 algorithm'
 Maintainers: ['JLivingstone@mednet.ucla.edu']
 Contributors: ['Julie Livingstone']
 Languages: ['Docker', 'bash']
-Tools: ['HISAT2']
+Tools: ['HISAT2', 'SAMtools v1.12']
 Version: ['2.2.1']
 Purpose of tool: 'Algorithm for aligning RNA-Seq data'
 Dependencies: ['Docker']


### PR DESCRIPTION
This version installs SAMtools 1.12 and HISAT2 with conda

This final docker is 416MB
while the version with SAMtools 1.11 and HISAT2 installed from downloaded tar.gz is only 262 MB

I am not sure why this is ...